### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=SparkFun Electronics
 maintainer=Jim Lindblom <jim@sparkfun.com>
 sentence=Driver library for SparkFun's MG2639 cellular shield.
 paragraph=Simple API to use SMS, TCP, and other functions made available by the MG2639 Cellular Shield.
+category=Communication
 url=http://github.com/sparkfun/MG2639_Cellular_Shield
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library SparkFun MG2639 CellShield is
not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.
