### PR TITLE
begin() now passing through return value from begin(unsigned long baud)

### DIFF
--- a/src/SFE_MG2639_CellShield.cpp
+++ b/src/SFE_MG2639_CellShield.cpp
@@ -105,7 +105,7 @@ uint8_t MG2639_Cell::begin()
 {
 	// begin() works just like begin([baud]), but we'll call
 	// TARGET_BAUD_RATE defined in the h file.
-	begin(TARGET_BAUD_RATE);
+	return begin(TARGET_BAUD_RATE);
 }
 
 //////////////////////


### PR DESCRIPTION
When called with no parameter the begin() method calls begin(unsigned
long baud) with a default value but it failed to pass on the return
value of that call resulting in all calls to begin() returning 0 which
may erroneously indicate a failure to initialize the hardware.